### PR TITLE
Add closing paren to JIRA/gerrit regex matchers

### DIFF
--- a/bots/gerrit-jira-translator.rb
+++ b/bots/gerrit-jira-translator.rb
@@ -184,7 +184,7 @@ class GerritJiraTranslator < SlackbotFrd::Bot
 
   def contains_jiras(str)
     # CNVS-12345 || TD-12345 || MBL-432 || OPS || SD || RD || ITSD || SE || DS || BR || CYOE || NTRS || PANDA
-    str.downcase =~ /(^|\s)\(?(CNVS|TD|MBL|OPS|SD|RD|ITSD|SE|DS|BR|CYOE|NTRS|PANDA)-\d{1,9}\)?[.!?,;]*($|\s)/i
+    str.downcase =~ /(^|\s)\(?(CNVS|TD|MBL|OPS|SD|RD|ITSD|SE|DS|BR|CYOE|NTRS|PANDA)-\d{1,9}\)?[.!?,;)]*($|\s)/i
   end
 
   def gerrit_url(gerr_num)

--- a/bots/gerrit-jira-translator.rb
+++ b/bots/gerrit-jira-translator.rb
@@ -179,7 +179,7 @@ class GerritJiraTranslator < SlackbotFrd::Bot
 
   def contains_gerrits(str)
     # g/12345
-    str.downcase =~ /(^|\s)g\/\d{3,9}[.!?,;]*($|\s)/i
+    str.downcase =~ /(^|\s)g\/\d{3,9}[.!?,;)]*($|\s)/i
   end
 
   def contains_jiras(str)


### PR DESCRIPTION
So when a JIRA/gerrit is enclosed in parens, it's still detected (eg, like this g/1234).
